### PR TITLE
G90 Set to absolute positioning before moving

### DIFF
--- a/octoprint_touchtest/static/js/touchtest.js
+++ b/octoprint_touchtest/static/js/touchtest.js
@@ -27,6 +27,7 @@ $(function() {
       code += " X" + xPos;
       code += " Y" + yPos;
       code += " F" + self.feedrate();
+      OctoPrint.control.sendGcode("G90"); //Set to Absolute Positioning
       OctoPrint.control.sendGcode(code);
       console.log("TouchTest: Sending command \"" + code +"\"");
     }


### PR DESCRIPTION
If the printer is still in relative mode (G91) the G0 commands can (and probably will) get out of range.