### PR TITLE
Add Python 3 compatibility string

### DIFF
--- a/octoprint_touchtest/__init__.py
+++ b/octoprint_touchtest/__init__.py
@@ -58,6 +58,7 @@ class TouchtestPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "Touchtest Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
This plugin does not have much Python at all, so it looks compatible to me. This is a requirement now to get updates to the plugin repository since Python 2 is EOL, and all new users very shortly will be Py3, so would not be able to install and run this plugin.

There's the documentation here, if you want to setup dual environments for testing:
https://docs.octoprint.org/en/master/plugins/python3_migration.html

Or, to update your existing environment, one time script:
https://octoprint.org/blog/2020/09/10/upgrade-to-py3/

Closes #24